### PR TITLE
Fix docs, update Readme

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -12,7 +12,7 @@ jobs:
     strategy:
       matrix:
         julia-version: ["lts", "1", "pre"]
-        os: [ubuntu-latest, macOS-latest, windows]
+        os: [ubuntu-latest, macOS-latest]
     steps:
       - uses: actions/checkout@v4
       - uses: julia-actions/setup-julia@v2

--- a/.gitignore
+++ b/.gitignore
@@ -1,2 +1,3 @@
 docs/Manifest.toml
 Manifest.toml
+docs/build

--- a/README.md
+++ b/README.md
@@ -1,6 +1,4 @@
 # StatisticalManifolds
 
-[![Stable](https://img.shields.io/badge/docs-stable-blue.svg)](https://Owner.github.io/StatisticalManifolds.jl/stable/)
 [![Dev](https://img.shields.io/badge/docs-dev-blue.svg)](https://Owner.github.io/StatisticalManifolds.jl/dev/)
-[![Build Status](https://github.com/Owner/StatisticalManifolds.jl/actions/workflows/CI.yml/badge.svg?branch=master)](https://github.com/Owner/StatisticalManifolds.jl/actions/workflows/CI.yml?query=branch%3Amaster)
-[![Coverage](https://codecov.io/gh/Owner/StatisticalManifolds.jl/branch/master/graph/badge.svg)](https://codecov.io/gh/Owner/StatisticalManifolds.jl)
+[![codecov](https://codecov.io/gh/JuliaManifolds/StatisticalManifolds.jl/graph/badge.svg?token=C9fJAPAx7E)](https://codecov.io/gh/JuliaManifolds/StatisticalManifolds.jl)

--- a/docs/Project.toml
+++ b/docs/Project.toml
@@ -1,3 +1,5 @@
 [deps]
 Documenter = "e30172f5-a6a5-5a46-863b-614d45cd2de4"
+DocumenterCitations = "daee34ce-89f3-4625-b898-19384cb65244"
+DocumenterInterLinks = "d12716ef-a0f6-4df4-a9f1-a5a34e75c656"
 StatisticalManifolds = "2d59fa81-9b3b-42d2-bf16-c012499602ea"

--- a/docs/make.jl
+++ b/docs/make.jl
@@ -33,7 +33,7 @@ makedocs(;
     #repo="https://github.com/jcrosser/StatisticalManifolds.jl/blob/{commit}{path}#{line}",
     sitename="StatisticalManifolds.jl",
     format=Documenter.HTML(; prettyurls=get(ENV, "CI", "false") == "true", assets=String[]),
-    pages=["Home" => "index.md"],
+    pages=["Home" => "index.md", "Literature" => "references.md"],
     plugins=[bib, links],
 )
 

--- a/docs/make.jl
+++ b/docs/make.jl
@@ -13,8 +13,20 @@ if Base.active_project() != joinpath(@__DIR__, "Project.toml")
 end
 
 using StatisticalManifolds
-using Documenter
+using Documenter, DocumenterCitations, DocumenterInterLinks
 
+bib = CitationBibliography(joinpath(@__DIR__, "src", "references.bib"); style=:alpha)
+links = InterLinks(
+    # Distributions seems to still render on a too old Documenter version
+    # "Distributions.jl" => ("https://juliastats.github.io/Distributions.jl/stable/"),
+    # Integrals seems to still render on a too old Documenter version
+    # "Integrals.jl" => ("https://docs.sciml.ai/Integrals/stable/"),
+    "ManifoldsBase" => ("https://juliamanifolds.github.io/ManifoldsBase.jl/stable/"),
+    "Manifolds" => ("https://juliamanifolds.github.io/Manifolds.jl/stable/"),
+    "Manopt" => ("https://manoptjl.org/stable/"),
+    # MCIntegration seems to still render on a too old Documenter version
+    #c"MCIntegration.jl" => ("https://numericaleft.github.io/MCIntegration.jl/stable/"),
+)
 makedocs(;
     modules=[StatisticalManifolds],
     authors="Jacob T. Crosser",
@@ -22,6 +34,7 @@ makedocs(;
     sitename="StatisticalManifolds.jl",
     format=Documenter.HTML(; prettyurls=get(ENV, "CI", "false") == "true", assets=String[]),
     pages=["Home" => "index.md"],
+    plugins=[bib, links],
 )
 
 deploydocs(;

--- a/docs/src/references.bib
+++ b/docs/src/references.bib
@@ -1,0 +1,39 @@
+# StatisticalManifolds.jl
+#
+# Literature used within the Documentation of StatisticalManifolds.jl
+# ========================================================
+#
+# citekeys should be of the form AllAuthors:Year, unless there is really many authors.
+#
+# ----------------------------------------------------------------------------------------
+@book{AbsilMahonySepulchre:2008,
+    AUTHOR    = {Absil, P.-A. and Mahony, R. and Sepulchre, R.},
+    DOI       = {10.1515/9781400830244},
+    NOTE      = {available online at [press.princeton.edu/chapters/absil/](http://press.princeton.edu/chapters/absil/)},
+    PUBLISHER = {Princeton University Press},
+    TITLE     = {Optimization Algorithms on Matrix Manifolds},
+    YEAR      = {2008}
+}
+@article{AxenBaranBergmannRzecki:2023,
+    ARTICLENO = {33},
+    AUTHOR    = {Axen, Seth D. and Baran, Mateusz and Bergmann, Ronny and Rzecki, Krzysztof},
+    DOI       = {10.1145/3618296},
+    JOURNAL   = {ACM Transactions on Mathematical Software},
+    MONTH     = {dec},
+    NUMBER    = {4},
+    TITLE     = {Manifolds.Jl: An Extensible Julia Framework for Data Analysis on Manifolds},
+    VOLUME    = {49},
+    YEAR      = {2023}
+}
+@book{Boumal:2023,
+    ABSTRACT  = {Optimization on Riemannian manifolds-the result of smooth geometry and optimization merging into one elegant modern framework-spans many areas of science and engineering, including machine learning, computer vision, signal processing, dynamical systems and scientific computing. This text introduces the differential geometry and Riemannian geometry concepts that will help students and researchers in applied mathematics, computer science and engineering gain a firm mathematical grounding to use these tools confidently in their research. Its charts-last approach will prove more intuitive from an optimizer's viewpoint, and all definitions and theorems are motivated to build time-tested optimization algorithms. Starting from first principles, the text goes on to cover current research on topics including worst-case complexity and geodesic convexity. Readers will appreciate the tricks of the trade for conducting research and for numerical implementations sprinkled throughout the book.},
+    AUTHOR    = {Boumal, Nicolas},
+    DOI       = {10.1017/9781009166164},
+    EDITION   = {First},
+    ISBN      = {978-1-00-916616-4},
+    MONTH     = mar,
+    PUBLISHER = {Cambridge University Press},
+    TITLE     = {An Introduction to Optimization on Smooth Manifolds},
+    URL       = {https://www.nicolasboumal.net/book/index.html},
+    YEAR      = {2023}
+}

--- a/docs/src/references.md
+++ b/docs/src/references.md
@@ -1,0 +1,4 @@
+# Literature
+
+```@bibliography
+```

--- a/src/expectation.jl
+++ b/src/expectation.jl
@@ -1,6 +1,6 @@
 ##### Dispatching function
 @doc raw"""
-    expectation(f::Function,d::Distribution;kwargs...) 
+    expectation(f::Function,d::Distribution;kwargs...)
 
 Numerically evaluate the expectation of `f(x)` against the probability density (mass) function `p(x|\theta)` over domain `\mathcal{D}` for distribution `d`
 
@@ -9,8 +9,8 @@ Numerically evaluate the expectation of `f(x)` against the probability density (
 \mathbb{E} := \sum_{x\in\mathca{D}} f(x)p(x|\theta)\,\,\,\text{Discrete}}
 ```
 
-This function acts as an interface between distriubtion obects from [`Distributions.jl`](@extref `Distributions.jl`) and the numerical methods from ['Integrals.jl`](@extref `Integrals.jl`)
-and [`MCIntegration.jl`](@extref `MCIntegration.jl`) for continuous distributions and [`Richardson.jl`](@extref `Richardson.jl`) for discrete distributions with an infinite domain.
+This function acts as an interface between distriubtion obects from [`Distributions.jl`](https://juliastats.github.io/Distributions.jl/stable/) and the numerical methods from ['Integrals.jl`](https://docs.sciml.ai/Integrals/stable/)
+and [`MCIntegration.jl`](https://numericaleft.github.io/MCIntegration.jl/stable/) for continuous distributions and [`Richardson.jl`](https://github.com/JuliaMath/Richardson.jl) for discrete distributions with an infinite domain.
 """
 expectation(f::Function, d::T; kwargs...) where {T} =
     _expectation(SupportStyle(typeof(d), d), f, d; kwargs...)


### PR DESCRIPTION
This PR is what I had planned on the one from yesterday

* the Readme is updated
  *  the `stable` link is removed for now, since this package only will have a stable version when a first version is registered
  * the `dev` link should work after this PR is merged
* I fixed the docs
  * I added `DocumenterCitations` and added a first few dummy citations. You could now add BibTeX citations into that file and refer to them with e.g. `[Boumal:2023](@cite)`
  * I added `DocumenterInterlinks` to link to other documentations entries – you tried to use that with `@extref` before, but that requires to load that packag
  * I had to change a few links, since some of the packages you wanted to `@extref` to seem to either have no docs (`Richardson.jl`) or have docs but seem to not yet render them with an up-to-date version, such that they generate the index the interlinks are based on. So I commented those out for now
* I added a fixed codecov badge to the Readme already. Sure you do not test yet, there is just one code line covered – but now one can see in the Readme the state of the tests.
* We could maybe also add further badges to the readme

With that working, this PR should also do a Preview – and after merge generate the `dev` vision of the docs once this runs on master. 